### PR TITLE
Add web page to display dynamic join birthday info

### DIFF
--- a/join-date.en.html
+++ b/join-date.en.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="Content-Language" content="en-US">
+    <title>Join the Site - Age Requirement</title>
+  </head>
+  <body>
+    To join the site, you must be at least <strong>18 years old</strong><span id="extra" class="hidden">, meaning you were born <strong>on or before <span id="date"></span></strong></span>.
+
+    <style>
+      .hidden {
+        display: none;
+      }
+    </style>
+
+    <script>
+      // Calculate date
+      var date = new Date();
+      date.setFullYear(date.getFullYear() - 18);
+
+      // Add information to span
+      var months = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'November', 'October', 'December'];
+      var month = months[date.getMonth()];
+      document.getElementById('date').innerText = month + ' ' + date.getDate() + ', ' + date.getFullYear();
+
+      // Unhide extra information section
+      document.getElementById('extra').classList.remove('hidden');
+    </script>
+  </body>
+</html>

--- a/join-date.en.html
+++ b/join-date.en.html
@@ -19,9 +19,7 @@
       date.setFullYear(date.getFullYear() - 18);
 
       // Add information to span
-      var months = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'November', 'October', 'December'];
-      var month = months[date.getMonth()];
-      document.getElementById('date').innerText = month + ' ' + date.getDate() + ', ' + date.getFullYear();
+      document.getElementById('date').innerText = Intl.DateTimeFormat().format(date);
 
       // Unhide extra information section
       document.getElementById('extra').classList.remove('hidden');

--- a/join-date.en.html
+++ b/join-date.en.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <link rel="stylesheet" href="https://cdn.scpwiki.com/theme/en/sigma/css/sigma.min.css">
-    <meta http-equiv="Content-Language" content="en-US">
+    <meta http-equiv="Content-Language" content="en">
     <title>Join the Site - Age Requirement</title>
   </head>
   <body>

--- a/join-date.en.html
+++ b/join-date.en.html
@@ -19,7 +19,12 @@
       date.setFullYear(date.getFullYear() - 18);
 
       // Add information to span
-      document.getElementById('date').innerText = Intl.DateTimeFormat().format(date);
+      var options = {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+      };
+      document.getElementById('date').innerText = Intl.DateTimeFormat('en', options).format(date);
 
       // Unhide extra information section
       document.getElementById('extra').classList.remove('hidden');

--- a/join-date.en.html
+++ b/join-date.en.html
@@ -14,17 +14,30 @@
     </style>
 
     <script>
+      function getLocale() {
+        if (navigator.languages && navigator.languages.length) {
+          return navigator.languages[0];
+        }
+
+        if (navigator.language) {
+          return navigator.language;
+        }
+
+        return 'en';
+      }
+
       // Calculate date
       var date = new Date();
       date.setFullYear(date.getFullYear() - 18);
 
       // Add information to span
+      var locale = getLocale();
       var options = {
         year: 'numeric',
         month: 'long',
         day: 'numeric',
       };
-      document.getElementById('date').innerText = Intl.DateTimeFormat('en', options).format(date);
+      document.getElementById('date').innerText = Intl.DateTimeFormat(locale, options).format(date);
 
       // Unhide extra information section
       document.getElementById('extra').classList.remove('hidden');

--- a/join-date.en.html
+++ b/join-date.en.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <link rel="stylesheet" href="https://cdn.scpwiki.com/theme/en/sigma/css/sigma.min.css">
     <meta http-equiv="Content-Language" content="en-US">
     <title>Join the Site - Age Requirement</title>
   </head>


### PR DESCRIPTION
As discussed in chat, it would be nice if we could automatically display the exact day prospective members would need to be born after in order to join. This can be done readily with some basic JS, which I have done here.

This comes after the creation of https://scp-sandbox-3.wikidot.com/join-site-scutoid-date as a prototype, but I have made some additional changes:

* It detects the locale of the browser and uses that if available.
* It does not use the deprecated `getYear()` function.
* Use of `var` to support a small subset of slightly older browsers.
* It supports noscript: if the page is loaded without JS then it simply omits the dynamic portion. Additionally, this also occurs if there is a runtime error in the javascript executed.
* It includes the Sigma-10 theme via URL, so it can rely on browser caching.

Because this HTML snippet only supports English, I have made the filetype `.en.html` instead of just `.html`. Since this is a smaller tool than the timer utilities I didn't think it made a lot of sense to invest time in better internationalization, rather than having each language branch create their own version by copying this file.

### Screenshots
With JS:
![image](https://github.com/user-attachments/assets/d753da0c-b198-4cc8-a23f-5690075761fc)

Without JS:
![image](https://github.com/user-attachments/assets/c39c645f-b4f9-4e34-a21a-d965a6006622)

With JS (error during loading):
![image](https://github.com/user-attachments/assets/50a7d968-dacd-4727-b346-5ab927742ba6)

With JS (browser locale set to Japanese):
![image](https://github.com/user-attachments/assets/1139aba5-a8c5-43b7-a556-958bed18ded6)
